### PR TITLE
Add email, github Jordy Detemmerman

### DIFF
--- a/web-ux.md
+++ b/web-ux.md
@@ -35,8 +35,8 @@
 	- github: https://github.com/naam/software-engineering-oplossingen.git
 
 - Detemmerman Jordy
-	- e-mailadres: naam@student.kdg.be
-	- github: https://github.com/naam/software-engineering-oplossingen.git
+	- e-mailadres: jordy.detemmerman@student.kdg.be
+	- github: https://github.com/Temeines/software-engineering-oplossingen.git
 
 - De Weze Caro
 	- e-mailadres: naam@student.kdg.be


### PR DESCRIPTION
Om één of andere reden wordt de laatste regel (in dit geval de github van Zenner Michaël) verwijdert en terug toegevoegd. Ik heb geen idee waarom dit gebeurt en heb al meerdere keren geprobeerd.